### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,14 +1,16 @@
 {
-	"perl" : "6.*",
-	"name" : "Date::WorkdayCalendar",
-	"version" : "0.1.0",
-	"description" : "Calendar and Date objects to handle business days, holidays and weekends",
-	"author" : "github:shinobi",
-	"depends" : [],
-	"provides" : {
-	        "WorkdayCalendar" : "lib/Date/WorkdayCalendar.pm",
-	        "Workdate" : "lib/Date/WorkdayCalendar.pm"
-	},
-	"source-url" : "git://github.com/perl6-community-modules/Date-WorkdayCalendar.git"
+  "name": "Date::WorkdayCalendar",
+  "source-url": "git://github.com/perl6-community-modules/Date-WorkdayCalendar.git",
+  "perl": "6.*",
+  "author": "github:shinobi",
+  "depends": [
+    
+  ],
+  "license": "Artistic-2.0",
+  "provides": {
+    "Workdate": "lib/Date/WorkdayCalendar.pm",
+    "WorkdayCalendar": "lib/Date/WorkdayCalendar.pm"
+  },
+  "version": "0.1.0",
+  "description": "Calendar and Date objects to handle business days, holidays and weekends"
 }
-


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license